### PR TITLE
fcarouge-kalman: add recipe

### DIFF
--- a/recipes/fcarouge-kalman/all/conandata.yml
+++ b/recipes/fcarouge-kalman/all/conandata.yml
@@ -1,0 +1,4 @@
+sources:
+  "0.5.1":
+    url: "https://github.com/FrancoisCarouge/Kalman/archive/refs/tags/0.5.1.tar.gz"
+    sha256: "b6d8ff8820cd42fa8b175c510f2bd0722564c5591cff1eb035664c0af35a5ada"

--- a/recipes/fcarouge-kalman/all/conanfile.py
+++ b/recipes/fcarouge-kalman/all/conanfile.py
@@ -1,0 +1,55 @@
+from conan import ConanFile
+from conan.tools.build import check_min_cppstd
+from conan.tools.cmake import cmake_layout, CMake
+from conan.tools.files import copy, get
+from conan.tools.layout import basic_layout
+import os
+
+required_conan_version = ">=2.1"
+
+
+class FcarougeKalmanConan(ConanFile):
+    name = "fcarouge-kalman"
+    description = "Kalman filters C++ library."
+    license = "Unlicense"
+    url = "https://github.com/conan-io/conan-center-index"
+    homepage = "https://github.com/FrancoisCarouge/Kalman"
+    topics = ("kalman", "control", "filter", "estimation")
+    package_type = "header-library"
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def validate(self):
+        check_min_cppstd(self, 23)
+
+    def package_id(self):
+        self.info.clear()
+
+    def layout(self):
+        cmake_layout(self, src_folder=".")
+
+    def source(self):
+        get(self, **self.conan_data["sources"][self.version], strip_root=True)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def package(self):
+        cmake = CMake(self)
+        cmake.install()
+        copy(
+            self,
+            "LICENSE.txt",
+            src=self.source_folder,
+            dst=os.path.join(self.package_folder, "licenses"),
+        )
+
+    def package_info(self):
+        self.cpp_info.set_property("cmake_file_name", "fcarouge-kalman")
+        self.cpp_info.set_property("cmake_target_name", "fcarouge-kalman::kalman")
+        self.cpp_info.set_property("pkg_config_name", "fcarouge-kalman")
+        self.cpp_info.libs = ["fcarouge-kalman"]
+        self.cpp_info.includedirs = ["include"]
+        self.cpp_info.bindirs = []

--- a/recipes/fcarouge-kalman/all/test_package/CMakeLists.txt
+++ b/recipes/fcarouge-kalman/all/test_package/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required(VERSION 3.25)
+project(test_package LANGUAGES CXX)
+
+find_package(fcarouge-kalman REQUIRED CONFIG)
+
+add_executable(${PROJECT_NAME} test_package.cpp)
+target_link_libraries(${PROJECT_NAME} PRIVATE fcarouge-kalman::kalman)

--- a/recipes/fcarouge-kalman/all/test_package/conanfile.py
+++ b/recipes/fcarouge-kalman/all/test_package/conanfile.py
@@ -1,0 +1,25 @@
+from conan import ConanFile
+from conan.tools.build import can_run
+from conan.tools.cmake import cmake_layout, CMake
+import os
+
+
+class TestPackageConan(ConanFile):
+    settings = "os", "arch", "compiler", "build_type"
+    generators = "CMakeDeps", "CMakeToolchain"
+
+    def layout(self):
+        cmake_layout(self)
+
+    def requirements(self):
+        self.requires(self.tested_reference_str)
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def test(self):
+        if can_run(self):
+            bin_path = os.path.join(self.cpp.build.bindir, "test_package")
+            self.run(bin_path, env="conanrun")

--- a/recipes/fcarouge-kalman/all/test_package/test_package.cpp
+++ b/recipes/fcarouge-kalman/all/test_package/test_package.cpp
@@ -1,0 +1,7 @@
+#include "fcarouge/kalman.hpp"
+
+#include <print>
+
+int main() {
+    std::println("{}", fcarouge::kalman{});
+}

--- a/recipes/fcarouge-kalman/config.yml
+++ b/recipes/fcarouge-kalman/config.yml
@@ -1,0 +1,3 @@
+versions:
+  "0.5.1":
+    folder: all


### PR DESCRIPTION
### Summary
Adds recipe:  **fcarouge-kalman/0.5.1**

#### Motivation
New recipe in support of the [Kalman](https://github.com/FrancoisCarouge/kalman) package.

#### Details
Initial recipe support for the C++23 and CMake project.
Tested on Ubuntu 22.04 and MacOS 15.4.1 with GCC14 and Clang 19.

---
- [x] Read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md)
- [x] Checked that this PR is not a duplicate: [list of PRs by recipe](https://github.com/conan-io/conan-center-index/discussions/24240)
- [x] Tested locally with at least one configuration using a recent version of Conan
